### PR TITLE
Build out storefront pages and backend-ready services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Base URL for the backend API. Example: https://api.yoursite.com or http://localhost:4000
+# Leave empty to use the built-in front-end mocks during local development.
+VITE_API_BASE_URL=
+
+# Set to "false" to force the front-end to call the API even if a base URL is present.
+# Defaults to using the mock data layer when unset.
+VITE_USE_MOCKS=true

--- a/README.md
+++ b/README.md
@@ -1,73 +1,54 @@
-# React + TypeScript + Vite
+# E-Commerce storefront
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A React + TypeScript storefront scaffolded with Vite and Tailwind CSS. It includes a themed layout, authentication flows wired
+into context, a product catalogue, cart management, and informational pages so you can focus on integrating your own backend.
 
-Currently, two official plugins are available:
+## Getting started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The app runs on [http://localhost:5173](http://localhost:5173) by default.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Environment variables
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+Copy `.env.example` to `.env` and adjust as needed:
+
+- `VITE_API_BASE_URL` – set this to your backend origin (e.g. `https://api.example.com`). When omitted, the front-end falls back to
+  the built-in mock data layer.
+- `VITE_USE_MOCKS` – defaults to `true`. Set to `false` to force live API calls when `VITE_API_BASE_URL` is configured.
+
+## Available scripts
+
+- `npm run dev` – start the Vite dev server.
+- `npm run build` – type-check and build for production.
+- `npm run preview` – preview the production build locally.
+
+## Features
+
+- **Design system tokens** for colors, typography, spacing, and layout applied through a `ThemeProvider`.
+- **Auth context** with login, signup, and profile flows. State is persisted in `localStorage` and ready to swap to your own API.
+- **Cart context** backed by a mock/localStorage service with add, update, remove, and clear actions.
+- **Product catalogue** pages powered by a catalog service that can point to your backend.
+- **Marketing pages** including shipping, returns, privacy, terms, and contact to match the navigation links.
+- **Promo ticker** with dismiss persistence and theme-aware styling.
+
+## Connecting a backend
+
+1. Implement REST endpoints that match the following routes (or update the services accordingly):
+   - `POST /auth/login`, `POST /auth/signup`, `GET /auth/me`, `POST /auth/logout`
+   - `GET /products`, `GET /products/:id`
+   - `GET /cart`, `POST /cart`, `PATCH /cart/:productId/:variantId`, `DELETE /cart/:productId/:variantId`, `POST /cart/clear`
+2. Set `VITE_API_BASE_URL` to the backend base URL and `VITE_USE_MOCKS=false`.
+3. Deploy the React app or continue iterating locally. The services in `src/services/` centralize API calls so you can customise
+   headers, authentication, or data transformation in one place.
+
+## Testing
+
+Run the production build (includes type-checking) before committing:
+
+```bash
+npm run build
 ```

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -1,21 +1,21 @@
-import React, { useState } from "react";
-import { login } from "../../mocks/auth";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
+import { useAuth } from "../../contexts/AuthContext";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const { login: authenticate } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
-      const user = await login({ email, password });
+      const user = await authenticate({ email, password });
       toast.success(`Welcome, ${user.name ?? user.email}`);
-      // TODO: set user in context/auth state
       navigate("/");
     } catch (err: any) {
       toast.error(err.message || "Login failed");

--- a/src/components/auth/Profile.tsx
+++ b/src/components/auth/Profile.tsx
@@ -1,16 +1,67 @@
-import React from "react";
+import { useMemo } from "react";
+import { useAuth } from "../../contexts/AuthContext";
 import { useThemeCtx } from "../layout/ThemeProvider";
-// dummy placeholder — in real app you'd fetch the current user
+
 export default function Profile() {
+  const { user, logout, loading } = useAuth();
   const { mode, toggle } = useThemeCtx();
+
+  const joined = useMemo(() => {
+    if (!user?.createdAt) return null;
+    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(new Date(user.createdAt));
+  }, [user?.createdAt]);
+
+  if (!user) {
+    return (
+      <div className="max-w-md mx-auto mt-[var(--space-2xl)] space-y-[var(--space-md)]">
+        <h2 className="text-2xl font-[var(--font-heading)] font-semibold">Profile</h2>
+        <p className="text-[var(--text-muted)]">
+          You need to sign in to view your profile.
+        </p>
+        <a href="/login" className="btn-primary inline-flex justify-center px-4 py-2">
+          Go to login
+        </a>
+      </div>
+    );
+  }
+
   return (
-    <div className="max-w-md mx-auto mt-[var(--space-2xl)] space-y-[var(--space-lg)]">
-      <h2 className="text-2xl font-[var(--font-heading)] font-semibold">Profile</h2>
-      <p>Logged in as: user@example.com</p>
-      <button onClick={toggle} className="btn-primary">
-        Toggle Theme (now {mode})
-      </button>
-      {/* Later: show address book, orders, settings */}
+    <div className="max-w-2xl mx-auto mt-[var(--space-2xl)] space-y-[var(--space-lg)]">
+      <header>
+        <h2 className="text-3xl font-[var(--font-heading)] font-semibold">Welcome back, {user.name ?? user.email}</h2>
+        {joined && <p className="text-[var(--text-muted)]">Member since {joined}</p>}
+      </header>
+
+      <section className="rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] p-[var(--space-lg)] space-y-[var(--space-sm)]">
+        <div className="flex flex-col gap-[var(--space-xs)]">
+          <span className="text-sm uppercase tracking-wide text-[var(--text-muted)]">Email</span>
+          <span className="text-lg font-medium">{user.email}</span>
+        </div>
+        {user.name && (
+          <div className="flex flex-col gap-[var(--space-xs)]">
+            <span className="text-sm uppercase tracking-wide text-[var(--text-muted)]">Name</span>
+            <span className="text-lg font-medium">{user.name}</span>
+          </div>
+        )}
+      </section>
+
+      <section className="flex flex-wrap gap-[var(--space-md)]">
+        <button
+          type="button"
+          className="btn-primary px-4 py-2"
+          onClick={toggle}
+        >
+          Toggle Theme (now {mode})
+        </button>
+        <button
+          type="button"
+          onClick={() => logout()}
+          className="border border-[var(--border)] rounded-[var(--radius-md)] px-4 py-2 hover:bg-[var(--surface)]"
+          disabled={loading}
+        >
+          {loading ? "Signing out..." : "Sign out"}
+        </button>
+      </section>
     </div>
   );
 }

--- a/src/components/auth/Signup.tsx
+++ b/src/components/auth/Signup.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { signup } from "../../mocks/auth";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
+import { useAuth } from "../../contexts/AuthContext";
 
 export default function Signup() {
   const [name, setName] = useState("");
@@ -9,12 +9,13 @@ export default function Signup() {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const { signup: register } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
-      const user = await signup({ name, email, password });
+      const user = await register({ name, email, password });
       toast.success(`Account created for ${user.email}`);
       navigate("/");
     } catch (err: any) {

--- a/src/components/cart/CartPage.tsx
+++ b/src/components/cart/CartPage.tsx
@@ -1,52 +1,182 @@
-import React from "react";
-import { mockCart, mockProducts } from "../../mocks/catalog";
-import type { CartItem } from "../../models/types";
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { useCart } from "../../contexts/CartContext";
+import { fetchProducts } from "../../services/catalog";
+import type { Product, ProductVariant } from "../../models/types";
+
+type DetailedCartItem = {
+  product: Product;
+  variant: ProductVariant;
+  quantity: number;
+  lineTotal: number;
+};
 
 export default function CartPage() {
-  const cart = mockCart;
+  const { cart, loading, removeItem, updateItemQuantity, clearCart } = useCart();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const getProduct = (productId: string) =>
-    mockProducts.find((p) => p.id === productId);
+  useEffect(() => {
+    let mounted = true;
+    setCatalogLoading(true);
+    fetchProducts()
+      .then((result) => {
+        if (mounted) setProducts(result);
+      })
+      .catch((err) => {
+        console.error("Failed to load products", err);
+        if (mounted) setError("Unable to load products right now");
+      })
+      .finally(() => {
+        if (mounted) setCatalogLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const items: DetailedCartItem[] = useMemo(() => {
+    if (!cart) return [];
+    return cart.items
+      .map((item) => {
+        const product = products.find((p) => p.id === item.productId);
+        const variant = product?.variants.find((v) => v.id === item.variantId);
+        if (!product || !variant) return null;
+        return {
+          product,
+          variant,
+          quantity: item.quantity,
+          lineTotal: variant.price.amount * item.quantity,
+        } satisfies DetailedCartItem;
+      })
+      .filter((value): value is DetailedCartItem => Boolean(value));
+  }, [cart, products]);
+
+  const currency = items[0]?.variant.price.currency ?? cart?.subtotal.currency ?? "CAD";
+  const subtotal = cart?.subtotal.amount ?? items.reduce((sum, item) => sum + item.lineTotal, 0);
+
+  const handleQuantityChange = async (productId: string, variantId: string, nextQuantity: number) => {
+    try {
+      await updateItemQuantity(productId, variantId, nextQuantity);
+    } catch (err: any) {
+      toast.error(err.message || "Unable to update quantity");
+    }
+  };
+
+  const handleRemove = async (productId: string, variantId: string) => {
+    try {
+      await removeItem(productId, variantId);
+      toast.success("Item removed from cart");
+    } catch (err: any) {
+      toast.error(err.message || "Unable to remove item");
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      await clearCart();
+      toast.success("Cart cleared");
+    } catch (err: any) {
+      toast.error(err.message || "Unable to clear cart");
+    }
+  };
+
+  const isEmpty = !items.length && !loading && !catalogLoading;
 
   return (
-    <div className="max-w-[var(--container-max)] mx-auto px-[var(--space-lg)] space-y-[var(--space-lg)]">
-      <h2 className="text-2xl font-[var(--font-heading)] font-semibold">Your Shopping Cart</h2>
-      {cart.items.length === 0 ? (
-        <p className="text-[var(--text-muted)]">Your cart is empty.</p>
+    <div className="max-w-[var(--container-max)] mx-auto space-y-[var(--space-lg)]">
+      <div className="flex items-center justify-between flex-wrap gap-[var(--space-md)]">
+        <div>
+          <h2 className="text-2xl font-[var(--font-heading)] font-semibold">Your Shopping Cart</h2>
+          {error && <p className="text-sm text-red-500 mt-[var(--space-xs)]">{error}</p>}
+        </div>
+        {!isEmpty && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-sm text-[var(--text-muted)] hover:text-[var(--accent)]"
+            disabled={loading}
+          >
+            Clear cart
+          </button>
+        )}
+      </div>
+
+      {loading || catalogLoading ? (
+        <p className="text-[var(--text-muted)]">Loading your items…</p>
+      ) : isEmpty ? (
+        <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--border)] p-[var(--space-xl)] text-center text-[var(--text-muted)]">
+          Your cart is empty. Browse our <a href="/products" className="text-[var(--accent)] underline">products</a> to add items.
+        </div>
       ) : (
         <ul className="divide-y divide-[var(--border)]">
-          {cart.items.map((item: CartItem) => {
-            const prod = getProduct(item.productId);
-            const variant = prod?.variants.find((v) => v.id === item.variantId);
-            if (!prod || !variant) return null;
-            return (
-              <li key={`${item.productId}-${item.variantId}`} className="flex items-center py-[var(--space-md)]">
-                <img src={variant.image ?? prod.images[0]} alt={prod.title} className="w-16 h-16 object-cover rounded-md" />
-                <div className="ml-[var(--space-md)] flex-1">
-                  <h3 className="font-[var(--font-heading)]">{prod.title}</h3>
-                  <p className="text-[var(--text-muted)]">
-                    {variant.attributes ? Object.entries(variant.attributes).map(([k, v]) => `${k}: ${v} `) : null}
+          {items.map(({ product, variant, quantity, lineTotal }) => (
+            <li key={`${product.id}-${variant.id}`} className="flex flex-col gap-[var(--space-sm)] py-[var(--space-md)] sm:flex-row sm:items-center">
+              <div className="flex items-center gap-[var(--space-md)] flex-1">
+                <img
+                  src={variant.image ?? product.images[0]}
+                  alt={product.title}
+                  className="w-20 h-20 object-cover rounded-[var(--radius-md)]"
+                />
+                <div className="space-y-[var(--space-xs)]">
+                  <h3 className="font-[var(--font-heading)] text-lg">{product.title}</h3>
+                  <p className="text-sm text-[var(--text-muted)]">
+                    {Object.entries(variant.attributes ?? {}).map(([key, value]) => `${key}: ${value}`).join(", ") || variant.title}
                   </p>
-                  <p className="mt-[var(--space-sm)]">Qty: {item.quantity}</p>
+                  <div className="flex items-center gap-[var(--space-sm)] text-sm">
+                    <label htmlFor={`qty-${product.id}-${variant.id}`} className="text-[var(--text-muted)]">
+                      Qty
+                    </label>
+                    <input
+                      id={`qty-${product.id}-${variant.id}`}
+                      type="number"
+                      min={1}
+                      value={quantity}
+                      onChange={(e) => {
+                        const parsed = Number(e.target.value);
+                        if (Number.isNaN(parsed)) return;
+                        handleQuantityChange(product.id, variant.id, Math.max(1, parsed));
+                      }}
+                      className="w-20 rounded border border-[var(--border)] bg-transparent px-2 py-1"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(product.id, variant.id)}
+                      className="text-xs text-red-500 hover:underline"
+                    >
+                      Remove
+                    </button>
+                  </div>
                 </div>
-                <span className="font-bold">
-                  ${(variant.price.amount * item.quantity / 100).toFixed(2)}
-                </span>
-              </li>
-            );
-          })}
+              </div>
+              <div className="text-right text-lg font-semibold">
+                ${(lineTotal / 100).toFixed(2)} {currency}
+              </div>
+            </li>
+          ))}
         </ul>
       )}
 
-      <div className="pt-[var(--space-lg)] border-t border-[var(--border)] flex justify-between text-lg">
-        <span>Subtotal</span>
-        <span className="font-bold">
-          ${(cart.subtotal.amount / 100).toFixed(2)} {cart.subtotal.currency}
-        </span>
-      </div>
-      <div className="mt-[var(--space-md)]">
-        <button className="btn-primary px-5 py-2">Proceed to Checkout</button>
-      </div>
+      {!isEmpty && (
+        <div className="pt-[var(--space-lg)] border-t border-[var(--border)] flex flex-col sm:flex-row sm:items-center sm:justify-between gap-[var(--space-md)] text-lg">
+          <div>
+            <span className="text-[var(--text-muted)]">Subtotal</span>
+          </div>
+          <div className="font-bold text-2xl">
+            ${(subtotal / 100).toFixed(2)} {currency}
+          </div>
+        </div>
+      )}
+
+      {!isEmpty && (
+        <div className="mt-[var(--space-md)] flex flex-wrap gap-[var(--space-md)]">
+          <button className="btn-primary px-5 py-3 text-base">Proceed to Checkout</button>
+          <a href="/products" className="px-5 py-3 text-base border border-[var(--border)] rounded-[var(--radius-md)] hover:bg-[var(--surface)]">
+            Continue shopping
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,9 +1,8 @@
-import { brand } from "../../config/brand"
+import { brand } from "../../config/brand";
 
 export default function Footer() {
   return (
-    <footer className="h-[var(--footer-height)] bg-[var(--surface)] border-t border-[var(--border)]
-                       flex items-center justify-center text-[var(--text-muted)] text-sm px-[var(--space-lg)]">
+    <footer className="h-[var(--footer-height)] bg-[var(--surface)] border-t border-[var(--border)] flex items-center justify-center text-[var(--text-muted)] text-sm px-[var(--space-lg)]">
       <div className="w-full max-w-[var(--container-max)] flex items-center justify-between">
         <p>&copy; {new Date().getFullYear()} {brand.company.legalName}</p>
         <div className="flex gap-[var(--space-md)]">

--- a/src/components/layout/PromoTicker.tsx
+++ b/src/components/layout/PromoTicker.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-import { useDismissable } from "../../hooks/useDismissable"
 import { usePromoVisibility } from "../../hooks/usePromoVisibility"
 import { tickerConfig } from "../../config/ticker";
 

--- a/src/components/layout/ThemeProvider.tsx
+++ b/src/components/layout/ThemeProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react";
-import { useTheme, type ThemeMode } from "../../hooks/useTheme";
+import { useTheme } from "../../hooks/useTheme";
 import type { PropsWithChildren } from "react";
 
 type Ctx = ReturnType<typeof useTheme>;

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -1,34 +1,73 @@
-import React from "react";
-import { mockProducts } from "../../mocks/catalog";
-import type { Product } from "../../models/types";
+import type { Product, ProductVariant } from "../../models/types";
 
-export default function ProductList() {
+type Props = {
+  products: Product[];
+  onAddToCart?: (product: Product, variant: ProductVariant) => void;
+};
+
+export default function ProductList({ products, onAddToCart }: Props) {
+  if (!products.length) {
+    return (
+      <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--border)] p-[var(--space-xl)] text-center text-[var(--text-muted)]">
+        No products found.
+      </div>
+    );
+  }
+
   return (
-    <div className="grid gap-[var(--space-lg)] grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 px-[var(--space-lg)]">
-      {mockProducts.map((product) => (
-        <ProductCard key={product.id} product={product} />
+    <div className="grid gap-[var(--space-lg)] grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} onAddToCart={onAddToCart} />
       ))}
     </div>
   );
 }
 
-function ProductCard({ product }: { product: Product }) {
+type CardProps = {
+  product: Product;
+  onAddToCart?: (product: Product, variant: ProductVariant) => void;
+};
+
+function ProductCard({ product, onAddToCart }: CardProps) {
   const variant = product.variants[0];
+  if (!variant) return null;
+
+  const handleClick = () => {
+    onAddToCart?.(product, variant);
+  };
+
   return (
-    <div className="bg-[var(--surface)] rounded-[var(--radius-md)] shadow p-[var(--space-md)] flex flex-col">
-      <img src={variant.image ?? product.images[0]} alt={product.title} className="w-full h-48 object-cover rounded-md" />
-      <h3 className="mt-[var(--space-sm)] text-lg font-[var(--font-heading)]">
-        {product.title}
-      </h3>
-      <p className="text-[var(--text-muted)] mt-[var(--space-sm)]">{product.description}</p>
-      <div className="mt-auto flex items-center justify-between">
-        <span className="font-bold">
-          ${(variant.price.amount / 100).toFixed(2)} {variant.price.currency}
-        </span>
-        <button className="btn-primary px-3 py-1 rounded-[var(--radius-sm)]">
-          Add to Cart
-        </button>
+    <article className="bg-[var(--surface)] rounded-[var(--radius-md)] shadow-sm border border-[color-mix(in oklab,var(--border) 80%,transparent)] overflow-hidden flex flex-col">
+      <div className="relative h-52 overflow-hidden">
+        <img
+          src={variant.image ?? product.images[0]}
+          alt={product.title}
+          className="w-full h-full object-cover transition-transform duration-500 hover:scale-105"
+          loading="lazy"
+        />
       </div>
-    </div>
+      <div className="flex flex-1 flex-col gap-[var(--space-sm)] p-[var(--space-md)]">
+        <div>
+          <h3 className="text-lg font-[var(--font-heading)] font-semibold">{product.title}</h3>
+          {product.description && (
+            <p className="text-sm text-[var(--text-muted)] mt-[var(--space-xs)]">
+              {product.description}
+            </p>
+          )}
+        </div>
+        <div className="mt-auto flex items-center justify-between">
+          <div className="font-semibold text-base">
+            ${(variant.price.amount / 100).toFixed(2)} {variant.price.currency}
+          </div>
+          <button
+            type="button"
+            onClick={handleClick}
+            className="btn-primary px-3 py-2 text-sm font-medium"
+          >
+            Add to Cart
+          </button>
+        </div>
+      </div>
+    </article>
   );
 }

--- a/src/config/brand.ts
+++ b/src/config/brand.ts
@@ -35,6 +35,7 @@ export type Brand = {
   marketing?: {
     heroTagline?: string;
     heroSub?: string;
+    heroImage?: string;
     featuredCategoriesTitle?: string;
     featuredCategoriesSubtitle?: string;
     featuredCategories?: { name: string; href: string }[];
@@ -48,8 +49,8 @@ export type Brand = {
 export const brand: Brand = {
   siteName: "E-Commerce",
   logo: {
-    light: "/logo-light.svg",
-    dark: "/logo-dark.svg",
+    light: "https://i.imgur.com/BgoFur0.png",
+    dark: "https://i.imgur.com/BgoFur0.png",
     alt: "E-Commerce",
   },
   company: {
@@ -82,7 +83,8 @@ export const brand: Brand = {
   marketing: {
     heroTagline: "Find the right style for your site.",
     heroSub: "Whiteglove E-Commerce.",
-    
+    heroImage: "https://images.unsplash.com/photo-1517940310602-4d2b220d9b6a?q=80&w=1600&auto=format&fit=crop",
+
     featuredCategoriesTitle: "Featured Categories",
     featuredCategoriesSubtitle: "Title 1, Title 2, Title 3, and more.",
     featuredCategories: [

--- a/src/config/promotions.ts
+++ b/src/config/promotions.ts
@@ -11,7 +11,7 @@ export type Promo = {
 
 export function getActivePromos(now = new Date()): Promo[] {
   const promos: Promo[] = [
-    { id: "fall20", text: "🔥 Fall Sale: 20% off", href: "/products?cat=title=1&promo=fall10", startAt: "2025-09-15T00:00:00Z", endAt: "2025-11-30T23:59:59Z", priority: 100, channels: ["ticker","homepage"] },
+    { id: "fall20", text: "🔥 Fall Sale: 20% off", href: "/products?cat=title-1&promo=fall20", startAt: "2025-09-15T00:00:00Z", endAt: "2025-11-30T23:59:59Z", priority: 100, channels: ["ticker","homepage"] },
     { id: "b3g1",   text: "⭐ Buy 3, Get 1 Free on select items", href: "/products?cat=title-2&promo=b3g1", startAt: "2025-10-01T00:00:00Z", endAt: "2025-10-31T23:59:59Z", priority: 90, channels: ["ticker"] },
     { id: "ship499",text: "🚚 Free shipping over $99", href: "/shipping", priority: 50, channels: ["ticker","homepage"] },
     // Example BNPL disclosure placeholder:

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,27 +1,114 @@
-import React, { createContext, useContext, useState } from "react";
-import type { ReactNode } from "react";
-import type { UserProfile } from "../models/types";
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import type { AuthCredentials, UserProfile } from "../models/types";
+import * as authService from "../services/auth";
 
 type AuthContextType = {
   user: UserProfile | null;
-  loginMock: (user: UserProfile) => void;
-  logout: () => void;
+  loading: boolean;
+  initialized: boolean;
+  login: (credentials: AuthCredentials) => Promise<UserProfile>;
+  signup: (data: AuthCredentials & { name?: string }) => Promise<UserProfile>;
+  logout: () => Promise<void>;
+  setUser: (profile: UserProfile | null) => void;
 };
+
+const STORAGE_KEY = "auth:user";
 
 const AuthCtx = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [initialized, setInitialized] = useState(false);
 
-  const loginMock = (user: UserProfile) => {
-    setUser(user);
-  };
-  const logout = () => {
-    setUser(null);
-  };
+  const persist = useCallback((profile: UserProfile | null) => {
+    if (typeof window === "undefined") return;
+    try {
+      if (profile) {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (err) {
+      console.warn("Failed to persist auth session", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const restore = async () => {
+      try {
+        const stored = typeof window !== "undefined" ? window.localStorage.getItem(STORAGE_KEY) : null;
+        if (stored) {
+          const parsed: UserProfile = JSON.parse(stored);
+          if (mounted) setUser(parsed);
+          return;
+        }
+
+        const profile = await authService.getProfile();
+        if (profile && mounted) {
+          setUser(profile);
+          persist(profile);
+        }
+      } catch (err) {
+        console.warn("Failed to restore auth session", err);
+      } finally {
+        if (mounted) setInitialized(true);
+      }
+    };
+
+    restore();
+
+    return () => {
+      mounted = false;
+    };
+  }, [persist]);
+
+  const login = useCallback(async (credentials: AuthCredentials) => {
+    setLoading(true);
+    try {
+      const profile = await authService.login(credentials);
+      setUser(profile);
+      persist(profile);
+      return profile;
+    } finally {
+      setLoading(false);
+      if (!initialized) setInitialized(true);
+    }
+  }, [initialized, persist]);
+
+  const signup = useCallback(async (data: AuthCredentials & { name?: string }) => {
+    setLoading(true);
+    try {
+      const profile = await authService.signup(data);
+      setUser(profile);
+      persist(profile);
+      return profile;
+    } finally {
+      setLoading(false);
+      if (!initialized) setInitialized(true);
+    }
+  }, [initialized, persist]);
+
+  const logout = useCallback(async () => {
+    setLoading(true);
+    try {
+      await authService.logout();
+    } finally {
+      setUser(null);
+      persist(null);
+      setLoading(false);
+    }
+  }, [persist]);
+
+  const setUserHandler = useCallback((profile: UserProfile | null) => {
+    setUser(profile);
+    persist(profile);
+  }, [persist]);
 
   return (
-    <AuthCtx.Provider value={{ user, loginMock, logout }}>
+    <AuthCtx.Provider value={{ user, loading, initialized, login, signup, logout, setUser: setUserHandler }}>
       {children}
     </AuthCtx.Provider>
   );

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import type { Cart } from "../models/types";
+import * as cartService from "../services/cart";
+
+type CartContextType = {
+  cart: Cart | null;
+  loading: boolean;
+  addItem: (productId: string, variantId: string, quantity?: number) => Promise<void>;
+  updateItemQuantity: (productId: string, variantId: string, quantity: number) => Promise<void>;
+  removeItem: (productId: string, variantId: string) => Promise<void>;
+  clearCart: () => Promise<void>;
+};
+
+const CartCtx = createContext<CartContextType | null>(null);
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+  const [cart, setCart] = useState<Cart | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    cartService
+      .fetchCart()
+      .then((data) => {
+        if (mounted) setCart(data);
+      })
+      .catch((err) => {
+        console.error("Failed to load cart", err);
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const addItem = useCallback(async (productId: string, variantId: string, quantity = 1) => {
+    const next = await cartService.addItem(productId, variantId, quantity);
+    setCart(next);
+  }, []);
+
+  const updateItemQuantity = useCallback(async (productId: string, variantId: string, quantity: number) => {
+    const next = await cartService.updateItemQuantity(productId, variantId, quantity);
+    setCart(next);
+  }, []);
+
+  const removeItem = useCallback(async (productId: string, variantId: string) => {
+    const next = await cartService.removeItem(productId, variantId);
+    setCart(next);
+  }, []);
+
+  const clearCartHandler = useCallback(async () => {
+    const next = await cartService.clearCart();
+    setCart(next);
+  }, []);
+
+  return (
+    <CartCtx.Provider value={{ cart, loading, addItem, updateItemQuantity, removeItem, clearCart: clearCartHandler }}>
+      {children}
+    </CartCtx.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartCtx);
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,9 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
-import ParallaxSection from './components/ui/ParallaxSection'
 import './index.css'
 import NotFound from './components/ui/NotFound'
 import { Toaster } from 'react-hot-toast'
-import { brand } from './config/brand'
-import ProductList from "./components/product/ProductList";
 import CartPage from './components/cart/CartPage'
 import Login from './components/auth/Login'
 import Signup from './components/auth/Signup'
@@ -14,75 +11,31 @@ import Profile from './components/auth/Profile'
 import Layout from './components/layout/Layout'
 import { ThemeProvider } from './components/layout/ThemeProvider'
 import { AuthProvider } from "./contexts/AuthContext";
-
-// Temporary demo pages
-function Home() {
-  const tagline = 
-  brand.marketing?.heroTagline ?? "Hero Tagline Here";
-  const sub = 
-  brand.marketing?.heroSub ?? "Subtext or supporting text goes here.";
-  const title = 
-  brand.marketing?.featuredCategoriesTitle ?? "Featured Categories";
-  const subtitle = 
-  brand.marketing?.featuredCategoriesSubtitle ?? "Tires • Rims • Auto Parts";
-  const categories = brand.marketing?.featuredCategories ?? [];
-  
-  if (!tagline) 
-    console.warn("No hero tagline set in brand.marketing.heroTagline");
-  else if (!sub)
-    console.warn("No hero subtext set in brand.marketing.heroSub");
-  else if (!categories || categories.length === 0)
-    console.warn("No featured categories set in brand.marketing.featuredCategories");
-  else if (!title)
-    console.warn("No featured categories title set in brand.marketing.featuredCategoriesTitle");
-  else if (!subtitle)
-    console.warn("No featured categories subtitle set in brand.marketing.featuredCategoriesSubtitle");
-  
-    return (
-    <div className="space-y-[var(--space-2xl)]">
-      <ParallaxSection
-        image="https://images.unsplash.com/photo-1517940310602-4d2b220d9b6a?q=80&w=1600&auto=format&fit=crop"
-        height="70vh"
-        strength={0.35}
-      >
-        <h1 className="text-4xl md:text-5xl font-[var(--font-heading)] font-bold text-[var(--text)]">
-          { tagline }
-        </h1>
-        <p className="mt-[var(--space-sm)] text-[var(--text-muted)]">
-          { sub }
-        </p>
-        <div className="mt-[var(--space-lg)]">
-          <a href="/products" className="btn-primary px-5 py-2 inline-block">
-            Shop Now
-          </a>
-        </div>
-      </ParallaxSection>
-
-      <section className="max-w-[var(--container-max)] mx-auto px-[var(--space-lg)]">
-        <h2 className="text-2xl font-[var(--font-heading)] font-semibold">
-          { title }
-        </h2>
-        <p className="text-[var(--text-muted)]">
-          { subtitle }
-        </p>
-      </section>
-    </div>
-  )
-}
-
-function Products() { return <ProductList /> }
+import { CartProvider } from "./contexts/CartContext";
+import Home from "./pages/Home";
+import ProductsPage from "./pages/ProductsPage";
+import ShippingPage from "./pages/ShippingPage";
+import ReturnsPage from "./pages/ReturnsPage";
+import PrivacyPage from "./pages/PrivacyPage";
+import TermsPage from "./pages/TermsPage";
+import ContactPage from "./pages/ContactPage";
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <Layout />,
     children: [
-      { index: true, element: <Home /> }, 
-      { path: 'products', element: <Products /> }, 
+      { index: true, element: <Home /> },
+      { path: 'products', element: <ProductsPage /> },
       { path: 'cart', element: <CartPage /> },
       { path: "login", element: <Login /> },
       { path: "signup", element: <Signup /> },
       { path: "profile", element: <Profile /> },
+      { path: "shipping", element: <ShippingPage /> },
+      { path: "returns", element: <ReturnsPage /> },
+      { path: "privacy", element: <PrivacyPage /> },
+      { path: "terms", element: <TermsPage /> },
+      { path: "contact", element: <ContactPage /> },
       { path: '*', element: <NotFound /> }, // catch-all 404
     ],
   },
@@ -92,8 +45,10 @@ createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider>
       <AuthProvider>
-      <Toaster position="top-right" />
-      <RouterProvider router={router} />
+        <CartProvider>
+          <Toaster position="top-right" />
+          <RouterProvider router={router} />
+        </CartProvider>
       </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,0 +1,41 @@
+import StaticPage, { type Section } from "./StaticPage";
+
+const sections: Section[] = [
+  {
+    heading: "Customer support",
+    body: (
+      <p>
+        Reach our support specialists at <a href="mailto:support@example.com" className="text-[var(--accent)]">support@example.com</a>
+        or call +1 (506) 555-0123 Monday through Friday, 9 a.m. – 6 p.m. Atlantic Time.
+      </p>
+    ),
+  },
+  {
+    heading: "Wholesale inquiries",
+    body: (
+      <p>
+        Interested in stocking our catalogue in your store? Email <a href="mailto:wholesale@example.com" className="text-[var(--accent)]">wholesale@example.com</a>
+        with your business details and we'll connect you with an account manager.
+      </p>
+    ),
+  },
+  {
+    heading: "Visit us",
+    body: (
+      <p>
+        Our showroom is located at 123 Main Street, Moncton, NB. Book an appointment to get personalized recommendations from our
+        product experts.
+      </p>
+    ),
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <StaticPage
+      title="Contact us"
+      intro="We're here to help with orders, product advice, and partnership opportunities."
+      sections={sections}
+    />
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import ParallaxSection from "../components/ui/ParallaxSection";
+import ProductList from "../components/product/ProductList";
+import { brand } from "../config/brand";
+import type { Product, ProductVariant } from "../models/types";
+import { fetchProducts } from "../services/catalog";
+import { useCart } from "../contexts/CartContext";
+
+export default function Home() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { addItem } = useCart();
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    fetchProducts()
+      .then((result) => {
+        if (mounted) setProducts(result);
+      })
+      .catch((err) => {
+        console.error("Failed to load products", err);
+        if (mounted) setError("We couldn't load featured products. Please try again later.");
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const featuredProducts = useMemo(() => products.slice(0, 3), [products]);
+
+  const handleAddToCart = async (product: Product, variant: ProductVariant) => {
+    try {
+      await addItem(product.id, variant.id, 1);
+      toast.success(`${product.title} added to cart`);
+    } catch (err: any) {
+      toast.error(err.message || "Could not add to cart");
+    }
+  };
+
+  const heroImage = brand.marketing?.heroImage ?? "https://images.unsplash.com/photo-1517940310602-4d2b220d9b6a?q=80&w=1600&auto=format&fit=crop";
+
+  return (
+    <div className="space-y-[var(--space-3xl)]">
+      <ParallaxSection image={heroImage} height="70vh" strength={0.3}>
+        <div className="space-y-[var(--space-md)]">
+          <p className="uppercase tracking-[0.4rem] text-sm text-[var(--text-muted)]">
+            {brand.siteName}
+          </p>
+          <h1 className="text-4xl md:text-6xl font-[var(--font-heading)] font-bold text-[var(--text)]">
+            {brand.marketing?.heroTagline ?? "Find your perfect fit."}
+          </h1>
+          <p className="text-lg text-[var(--text-muted)] max-w-2xl mx-auto">
+            {brand.marketing?.heroSub ?? "White-glove e-commerce for modern retailers."}
+          </p>
+          <div className="flex flex-wrap justify-center gap-[var(--space-md)]">
+            <a href="/products" className="btn-primary px-6 py-3 text-base font-semibold">
+              Shop Now
+            </a>
+            <a
+              href={brand.links.contact}
+              className="px-6 py-3 text-base border border-[var(--border)] rounded-[var(--radius-md)] hover:bg-[var(--surface)]"
+            >
+              Talk to us
+            </a>
+          </div>
+        </div>
+      </ParallaxSection>
+
+      <section className="max-w-[var(--container-max)] mx-auto space-y-[var(--space-lg)] px-[var(--space-lg)]">
+        <header className="space-y-[var(--space-xs)] text-center">
+          <h2 className="text-3xl font-[var(--font-heading)] font-semibold">
+            {brand.marketing?.featuredCategoriesTitle ?? "Featured Categories"}
+          </h2>
+          <p className="text-[var(--text-muted)]">
+            {brand.marketing?.featuredCategoriesSubtitle ?? "Shop our most popular collections."}
+          </p>
+        </header>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-[var(--space-lg)]">
+          {(brand.marketing?.featuredCategories ?? []).map((category) => (
+            <a
+              key={category.name}
+              href={category.href}
+              className="group rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface)] p-[var(--space-lg)] shadow-sm hover:border-[var(--accent)] transition"
+            >
+              <h3 className="text-xl font-semibold mb-[var(--space-sm)] group-hover:text-[var(--accent)]">
+                {category.name}
+              </h3>
+              <span className="text-sm text-[var(--text-muted)] group-hover:text-[var(--accent)]">Shop now →</span>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="max-w-[var(--container-max)] mx-auto space-y-[var(--space-lg)] px-[var(--space-lg)]">
+        <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-[var(--space-md)]">
+          <div>
+            <h2 className="text-3xl font-[var(--font-heading)] font-semibold">Latest arrivals</h2>
+            <p className="text-[var(--text-muted)]">Handpicked gear to elevate your build.</p>
+          </div>
+          <a href="/products" className="text-[var(--accent)] font-medium">View all products</a>
+        </header>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        {loading ? (
+          <p className="text-[var(--text-muted)]">Loading featured products…</p>
+        ) : (
+          <ProductList products={featuredProducts} onAddToCart={handleAddToCart} />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,0 +1,42 @@
+import StaticPage, { type Section } from "./StaticPage";
+
+const sections: Section[] = [
+  {
+    heading: "Personal information we collect",
+    body: (
+      <p>
+        We collect contact details, shipping addresses, payment details, and browsing activity to fulfill orders and improve the
+        shopping experience. Sensitive payment data is handled by certified payment providers.
+      </p>
+    ),
+  },
+  {
+    heading: "How we use your data",
+    body: (
+      <ul className="list-disc pl-6 space-y-[var(--space-xs)]">
+        <li>To process transactions and provide customer support.</li>
+        <li>To personalize merchandising and marketing communications.</li>
+        <li>To maintain security and prevent fraudulent activity.</li>
+      </ul>
+    ),
+  },
+  {
+    heading: "Your choices",
+    body: (
+      <p>
+        You can update preferences or request data deletion anytime by contacting our support team at privacy@example.com.
+        Marketing emails include an unsubscribe link in every message.
+      </p>
+    ),
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <StaticPage
+      title="Privacy policy"
+      intro="We respect your privacy and explain how your information is handled."
+      sections={sections}
+    />
+  );
+}

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+import ProductList from "../components/product/ProductList";
+import { fetchProducts } from "../services/catalog";
+import type { Product, ProductVariant } from "../models/types";
+import { useCart } from "../contexts/CartContext";
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { addItem } = useCart();
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    fetchProducts()
+      .then((result) => {
+        if (mounted) setProducts(result);
+      })
+      .catch((err) => {
+        console.error("Failed to load products", err);
+        if (mounted) setError("We couldn't load products. Please try again later.");
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleAddToCart = async (product: Product, variant: ProductVariant) => {
+    try {
+      await addItem(product.id, variant.id, 1);
+      toast.success(`${product.title} added to cart`);
+    } catch (err: any) {
+      toast.error(err.message || "Could not add to cart");
+    }
+  };
+
+  return (
+    <div className="max-w-[var(--container-max)] mx-auto space-y-[var(--space-lg)]">
+      <header className="space-y-[var(--space-xs)]">
+        <h1 className="text-3xl font-[var(--font-heading)] font-semibold">Products</h1>
+        <p className="text-[var(--text-muted)]">Browse the complete catalogue.</p>
+      </header>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      {loading ? (
+        <p className="text-[var(--text-muted)]">Loading products…</p>
+      ) : (
+        <ProductList products={products} onAddToCart={handleAddToCart} />
+      )}
+    </div>
+  );
+}

--- a/src/pages/ReturnsPage.tsx
+++ b/src/pages/ReturnsPage.tsx
@@ -1,0 +1,42 @@
+import StaticPage, { type Section } from "./StaticPage";
+
+const sections: Section[] = [
+  {
+    heading: "Easy returns",
+    body: (
+      <p>
+        If something isn't right, you have 30 days from delivery to start a return. Items must be unused and in their original
+        packaging. Clearance or custom orders are final sale.
+      </p>
+    ),
+  },
+  {
+    heading: "How to start a return",
+    body: (
+      <ol className="list-decimal pl-6 space-y-[var(--space-xs)]">
+        <li>Log in to your account and open the order you'd like to return.</li>
+        <li>Click “Request return” and select the items and reason.</li>
+        <li>We'll email a prepaid shipping label once the request is approved.</li>
+      </ol>
+    ),
+  },
+  {
+    heading: "Refund timing",
+    body: (
+      <p>
+        Refunds are issued to the original payment method within 5 business days after the returned items arrive at our
+        warehouse. You'll receive an email confirmation when the refund is processed.
+      </p>
+    ),
+  },
+];
+
+export default function ReturnsPage() {
+  return (
+    <StaticPage
+      title="Returns & exchanges"
+      intro="Shop confidently knowing you can exchange or return within 30 days."
+      sections={sections}
+    />
+  );
+}

--- a/src/pages/ShippingPage.tsx
+++ b/src/pages/ShippingPage.tsx
@@ -1,0 +1,42 @@
+import StaticPage, { type Section } from "./StaticPage";
+
+const sections: Section[] = [
+  {
+    heading: "Delivery options",
+    body: (
+      <ul className="list-disc pl-6 space-y-[var(--space-xs)]">
+        <li>Standard ground shipping (3-5 business days) via national carriers.</li>
+        <li>Expedited 2-day delivery available in major Canadian cities.</li>
+        <li>Free in-store pickup for local customers within 24 hours.</li>
+      </ul>
+    ),
+  },
+  {
+    heading: "Order processing",
+    body: (
+      <p>
+        Orders placed before 3 p.m. Atlantic Time ship the same business day. Tracking details are emailed as soon as your
+        package leaves our warehouse.
+      </p>
+    ),
+  },
+  {
+    heading: "Shipping rates",
+    body: (
+      <p>
+        Shipping is calculated at checkout based on destination, weight, and delivery speed. Orders over $99 automatically qualify
+        for free ground shipping across Canada.
+      </p>
+    ),
+  },
+];
+
+export default function ShippingPage() {
+  return (
+    <StaticPage
+      title="Shipping information"
+      intro="Learn how we fulfill and deliver your orders across Canada."
+      sections={sections}
+    />
+  );
+}

--- a/src/pages/StaticPage.tsx
+++ b/src/pages/StaticPage.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+export type Section = {
+  heading: string;
+  body: ReactNode;
+};
+
+type Props = {
+  title: string;
+  intro?: ReactNode;
+  sections?: Section[];
+};
+
+export default function StaticPage({ title, intro, sections = [] }: Props) {
+  return (
+    <div className="max-w-[var(--container-max)] mx-auto space-y-[var(--space-xl)]">
+      <header className="space-y-[var(--space-xs)]">
+        <h1 className="text-4xl font-[var(--font-heading)] font-semibold">{title}</h1>
+        {intro && <div className="text-[var(--text-muted)] text-lg">{intro}</div>}
+      </header>
+      <div className="space-y-[var(--space-lg)]">
+        {sections.map((section) => (
+          <section
+            key={section.heading}
+            className="rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] p-[var(--space-lg)] space-y-[var(--space-sm)]"
+          >
+            <h2 className="text-2xl font-[var(--font-heading)] font-semibold">{section.heading}</h2>
+            <div className="text-[var(--text-muted)] leading-relaxed space-y-[var(--space-sm)]">{section.body}</div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,41 @@
+import StaticPage, { type Section } from "./StaticPage";
+
+const sections: Section[] = [
+  {
+    heading: "Agreement to terms",
+    body: (
+      <p>
+        By accessing our website you agree to abide by these terms and all applicable laws. If you disagree with any part of the
+        terms, you may not access the site.
+      </p>
+    ),
+  },
+  {
+    heading: "Products and pricing",
+    body: (
+      <p>
+        We work to ensure accuracy but reserve the right to correct pricing errors and update availability without prior notice.
+        Taxes and shipping are calculated at checkout based on your location.
+      </p>
+    ),
+  },
+  {
+    heading: "Limitation of liability",
+    body: (
+      <p>
+        E-Commerce and its suppliers are not liable for indirect or consequential damages arising from the use of this site.
+        Some jurisdictions do not allow limitations, so these limitations may not apply to you.
+      </p>
+    ),
+  },
+];
+
+export default function TermsPage() {
+  return (
+    <StaticPage
+      title="Terms & conditions"
+      intro="Review the legal terms that govern use of our website and services."
+      sections={sections}
+    />
+  );
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,55 @@
+import type { AuthCredentials, UserProfile } from "../models/types";
+import { login as mockLogin, signup as mockSignup } from "../mocks/auth";
+import { apiFetch, usingMocks } from "./http";
+
+const LOGIN_ENDPOINT = "/auth/login";
+const SIGNUP_ENDPOINT = "/auth/signup";
+const PROFILE_ENDPOINT = "/auth/me";
+const LOGOUT_ENDPOINT = "/auth/logout";
+
+export async function login(credentials: AuthCredentials): Promise<UserProfile> {
+  if (usingMocks()) {
+    return mockLogin(credentials);
+  }
+
+  return apiFetch<UserProfile>(LOGIN_ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify(credentials),
+  });
+}
+
+export async function signup(data: AuthCredentials & { name?: string }): Promise<UserProfile> {
+  if (usingMocks()) {
+    return mockSignup({ ...data, name: data.name ?? data.email.split("@")[0] });
+  }
+
+  return apiFetch<UserProfile>(SIGNUP_ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getProfile(): Promise<UserProfile | null> {
+  if (usingMocks()) {
+    return null;
+  }
+
+  try {
+    return await apiFetch<UserProfile>(PROFILE_ENDPOINT, { method: "GET" });
+  } catch (err) {
+    console.warn("Failed to fetch profile", err);
+    return null;
+  }
+}
+
+export async function logout(): Promise<void> {
+  if (usingMocks()) {
+    return;
+  }
+
+  try {
+    await apiFetch<void>(LOGOUT_ENDPOINT, { method: "POST" });
+  } catch (err) {
+    console.warn("Failed to call logout endpoint", err);
+  }
+}

--- a/src/services/cart.ts
+++ b/src/services/cart.ts
@@ -1,0 +1,144 @@
+import type { Cart, CartItem } from "../models/types";
+import { mockProducts } from "../mocks/catalog";
+import { apiFetch, usingMocks } from "./http";
+
+const CART_STORAGE_KEY = "cart-state";
+const CART_ENDPOINT = "/cart";
+
+function createEmptyCart(): Cart {
+  const currency = mockProducts[0]?.variants[0]?.price.currency ?? "CAD";
+  return {
+    items: [],
+    subtotal: { amount: 0, currency },
+    total: { amount: 0, currency },
+  };
+}
+
+function readLocalCart(): Cart {
+  if (typeof window === "undefined") {
+    return createEmptyCart();
+  }
+  try {
+    const raw = window.localStorage.getItem(CART_STORAGE_KEY);
+    if (!raw) {
+      return createEmptyCart();
+    }
+    const parsed: Cart = JSON.parse(raw);
+    return recalculateTotals(parsed.items);
+  } catch {
+    return createEmptyCart();
+  }
+}
+
+function writeLocalCart(cart: Cart) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(cart));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+function recalculateTotals(items: CartItem[]): Cart {
+  let amount = 0;
+  for (const item of items) {
+    const product = mockProducts.find((p) => p.id === item.productId);
+    const variant = product?.variants.find((v) => v.id === item.variantId);
+    if (!variant) continue;
+    amount += variant.price.amount * item.quantity;
+  }
+
+  const currency = mockProducts[0]?.variants[0]?.price.currency ?? "CAD";
+
+  return {
+    items,
+    subtotal: { amount, currency },
+    total: { amount, currency },
+  };
+}
+
+export async function fetchCart(): Promise<Cart> {
+  if (usingMocks()) {
+    return readLocalCart();
+  }
+
+  return apiFetch<Cart>(CART_ENDPOINT, { method: "GET" });
+}
+
+export async function addItem(productId: string, variantId: string, quantity = 1): Promise<Cart> {
+  if (usingMocks()) {
+    const cart = readLocalCart();
+    const existing = cart.items.find(
+      (item) => item.productId === productId && item.variantId === variantId
+    );
+
+    if (existing) {
+      existing.quantity += quantity;
+    } else {
+      cart.items.push({ productId, variantId, quantity });
+    }
+
+    const next = recalculateTotals(cart.items);
+    writeLocalCart(next);
+    return next;
+  }
+
+  return apiFetch<Cart>(CART_ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify({ productId, variantId, quantity }),
+  });
+}
+
+export async function updateItemQuantity(productId: string, variantId: string, quantity: number): Promise<Cart> {
+  if (quantity <= 0) {
+    return removeItem(productId, variantId);
+  }
+
+  if (usingMocks()) {
+    const cart = readLocalCart();
+    const existing = cart.items.find(
+      (item) => item.productId === productId && item.variantId === variantId
+    );
+
+    if (existing) {
+      existing.quantity = quantity;
+    }
+
+    const next = recalculateTotals(cart.items);
+    writeLocalCart(next);
+    return next;
+  }
+
+  return apiFetch<Cart>(`${CART_ENDPOINT}/${productId}/${variantId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ quantity }),
+  });
+}
+
+export async function removeItem(productId: string, variantId: string): Promise<Cart> {
+  if (usingMocks()) {
+    const cart = readLocalCart();
+    const nextItems = cart.items.filter(
+      (item) => !(item.productId === productId && item.variantId === variantId)
+    );
+    const next = recalculateTotals(nextItems);
+    writeLocalCart(next);
+    return next;
+  }
+
+  return apiFetch<Cart>(`${CART_ENDPOINT}/${productId}/${variantId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function clearCart(): Promise<Cart> {
+  if (usingMocks()) {
+    const cleared = createEmptyCart();
+    writeLocalCart(cleared);
+    return cleared;
+  }
+
+  return apiFetch<Cart>(`${CART_ENDPOINT}/clear`, { method: "POST" });
+}

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -1,0 +1,21 @@
+import type { Product } from "../models/types";
+import { mockProducts } from "../mocks/catalog";
+import { apiFetch, usingMocks } from "./http";
+
+const PRODUCTS_ENDPOINT = "/products";
+
+export async function fetchProducts(): Promise<Product[]> {
+  if (usingMocks()) {
+    return mockProducts;
+  }
+
+  return apiFetch<Product[]>(PRODUCTS_ENDPOINT, { method: "GET" });
+}
+
+export async function fetchProductById(id: string): Promise<Product | undefined> {
+  if (usingMocks()) {
+    return mockProducts.find((p) => p.id === id);
+  }
+
+  return apiFetch<Product>(`${PRODUCTS_ENDPOINT}/${id}`, { method: "GET" });
+}

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,67 @@
+const baseUrl = import.meta.env.VITE_API_BASE_URL?.trim() || "";
+const useMocksEnv = import.meta.env.VITE_USE_MOCKS?.trim()?.toLowerCase();
+
+const shouldUseMocks =
+  !baseUrl ||
+  useMocksEnv === undefined ||
+  useMocksEnv === "" ||
+  useMocksEnv === "true";
+
+export const apiConfig = {
+  baseUrl,
+  shouldUseMocks,
+};
+
+export function isApiConfigured() {
+  return Boolean(baseUrl);
+}
+
+export function usingMocks() {
+  return shouldUseMocks;
+}
+
+export type ApiRequestInit = RequestInit & {
+  /**
+   * Set to false if you want to send FormData or other body types without JSON headers.
+   * Defaults to true, automatically applying JSON content type + accept headers.
+   */
+  json?: boolean;
+};
+
+export async function apiFetch<T>(path: string, init: ApiRequestInit = {}): Promise<T> {
+  if (!baseUrl) {
+    throw new Error(
+      "VITE_API_BASE_URL is not configured. Provide it or keep VITE_USE_MOCKS=true to rely on the front-end mocks."
+    );
+  }
+
+  const { json = true, headers, ...rest } = init;
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    credentials: "include",
+    headers: json
+      ? {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          ...(headers ?? {}),
+        }
+      : headers,
+    ...rest,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText || "Request failed");
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (contentType && contentType.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+
+  return (await response.text()) as unknown as T;
+}


### PR DESCRIPTION
## Summary
- add reusable API services and cart/auth contexts so the front-end can switch between mocks and a live backend
- build rich home, product, cart, and policy pages that align with the navigation and marketing content
- document environment variables and ship an example env file for configuring the backend connection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5b2636bf88320922718e83acc2455